### PR TITLE
limit permissions on security considerations github action

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,5 +1,8 @@
 name: Security Considerations
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]


### PR DESCRIPTION
## Changes proposed in this pull request:

- limit permissions of Security Considerations GitHub action

## security considerations

Limiting permissions for GitHub action follows principle of least privilege